### PR TITLE
[chart:vault:stakater] Added security context privilege for Openshift

### DIFF
--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -67,6 +67,10 @@ spec:
             periodSeconds: {{ .Values.csi.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.csi.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
+          {{- if .Values.global.openshift }}
+          securityContext:
+            privileged: true
+          {{- end }}  
       volumes:
         - name: providervol
           hostPath:


### PR DESCRIPTION
This is the security context privilege for vault-csi-provider.